### PR TITLE
Limpa cookie de sessão ao utilizar sessão expirada

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -35,11 +35,12 @@ async function onNoMatchHandler(request, response) {
   response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
 async function onErrorHandler(error, request, response) {
-  if (
-    error instanceof ValidationError ||
-    error instanceof NotFoundError ||
-    error instanceof UnauthorizedError
-  ) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
+    return response.status(error.statusCode).json(error);
+  }
+
+  if (error instanceof UnauthorizedError) {
+    clearSessionCookie(response);
     return response.status(error.statusCode).json(error);
   }
 

--- a/models/session.js
+++ b/models/session.js
@@ -39,7 +39,7 @@ async function findOneValidByToken(sessionToken) {
 async function renew(sessionId) {
   const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
 
-  const renewedSessionObject = runUpdateQuery(sessionId, expiresAt);
+  const renewedSessionObject = await runUpdateQuery(sessionId, expiresAt);
   return renewedSessionObject;
 
   async function runUpdateQuery(sessionId, expiresAt) {

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -149,6 +149,19 @@ describe("GET /api/v1/user", () => {
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
       });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
+      });
     });
 
     test("With expired session", async () => {
@@ -179,6 +192,19 @@ describe("GET /api/v1/user", () => {
         message: "Usuário não possui sessão ativa.",
         action: "Verifique se este usuário está logado e tente novamente.",
         status_code: 401,
+      });
+
+      // Set-Cookie assertions
+      const parsedSetCookie = setCookieParser(response, {
+        map: true,
+      });
+
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: "invalid",
+        maxAge: -1,
+        path: "/",
+        httpOnly: true,
       });
     });
   });


### PR DESCRIPTION
Este Pull Request é composto por dois commits:

1. Dentro do controller.js na parte onde ele recebe os erros (onErrorHandler), separa em sua própria condicional o que é um UnauthorizedError para que neste caso seja devolvido um cabeçalho Set-Cookie com o objetivo de limpar o session_id do client.

2. Adiciona a falta de um await dentro do session.renew() que foi apontado por @alankewem